### PR TITLE
Updates to run on RedHat/CentOS 6 with latest version

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,8 +6,8 @@ class oxidized::config {
 
   concat { $oxidized::params::oxidized_config:
     ensure => present,
-    owner  => oxidized,
-    group  => oxidized,
+    owner  => $oxidized::oxidized_user,
+    group  => $oxidized::oxidized_group,
     mode   => '0644',
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,14 @@ class oxidized::config {
     mode   => '0644',
   }
 
+  file {
+    '/etc/oxidized':
+        ensure => directory,
+        owner  => $oxidized::oxidized_user,
+        group  => $oxidized::oxidized_group,
+        mode   => '0640';
+  }
+
   concat::fragment { 'global_oxidized_config':
     target  => $oxidized::params::oxidized_config,
     content => template("${module_name}/main_options.erb"),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,10 +12,12 @@
 #
 class oxidized (
 
-  $main_options = {},
-  $password     = $oxidized::params::password,
-  $gem          = $oxidized::params::gem,
-  $version      = 'present',
+  $main_options   = {},
+  $password       = $oxidized::params::password,
+  $gem            = $oxidized::params::gem,
+  $version        = 'present',
+  $oxidized_user  = $oxidized::params::user,
+  $oxidized_group = $oxidized::params::group,
 
 ) inherits oxidized::params {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,7 @@ class oxidized::install {
 
   include oxidized::params
 
-  if $oxidized::params::gem {
+  if $oxidized::gem {
     package { $oxidized::params::dependencies:
       ensure  => $oxidized::main::ensure,
     } ->

--- a/manifests/main.pp
+++ b/manifests/main.pp
@@ -13,7 +13,7 @@ class oxidized::main (
   if $password == undef {
     fail('Please set a password.')
   }
-  
+
   $fin_pass = {
     password => $password,
   }
@@ -25,7 +25,7 @@ class oxidized::main (
     undef   => $options,
     default => $hiera_options,
   }
-  
+
   $merged_options = merge($fin_pass, $oxidized::params::default_options, $fin_options)
 
   include oxidized::install

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,8 @@ class oxidized::params {
   $gem                = true
   $gem_names          = [ 'oxidized', 'oxidized-script', 'oxidized-web' ]
   $oxidized_config    = '/etc/oxidized.conf'
+  $user               = 'oxidized'
+  $group              = 'oxidized'
 
   $default_options = {
     username   => 'oxidized',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,7 +58,7 @@ class oxidized::params {
   $password           = undef
   $gem                = true
   $gem_names          = [ 'oxidized', 'oxidized-script', 'oxidized-web' ]
-  $oxidized_config    = '/etc/oxidized.conf'
+  $oxidized_config    = '/etc/oxidized/config'
   $user               = 'oxidized'
   $group              = 'oxidized'
 
@@ -76,7 +76,7 @@ class oxidized::params {
     vars       => {},
     groups     => {},
     model_map  => {},
-    restapi    => '127.0.0.1:8888',
+    rest       => '127.0.0.1:8888',
     input      => {
       'default'  => 'ssh, telnet',
       debug    => false,
@@ -94,6 +94,14 @@ class oxidized::params {
     },
     source      => {
       'default' => 'csv',
+      'csv' => {
+        'file'      =>  '/etc/oxidized/router.db',
+        'delimiter' => ':',
+        'map'       => {
+            'name'  => 0,
+            'model' => 1,
+        },
+      },
     },
     hooks => {},
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,10 @@ class oxidized::params {
     }
     redhat: {
       case $::lsbmajdistrelease {
+        '6': {
+          $dependencies  = [ 'cmake', 'sqlite-devel', 'openssl-devel', 'libssh2-devel', 'ruby', 'gcc', 'ruby-devel' ]
+          $package_names = [ 'ruby200-rubygem-oxidized', 'ruby200-rubygem-oxidized-web', 'ruby200-rubygem-oxidized-script' ]
+        }
         7: {
           $dependencies  = [ 'cmake', 'sqlite-devel', 'openssl-devel', 'libssh2-devel', 'ruby', 'gcc', 'ruby-devel' ]
           $package_names = [ 'rubygem-oxidized', 'rubygem-oxidized-web', 'rubygem-oxidized-script' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,7 @@ class oxidized::params {
   $gem                = true
   $gem_names          = [ 'oxidized', 'oxidized-script', 'oxidized-web' ]
   $oxidized_config    = '/etc/oxidized/config'
+  $service_name       = 'oxidized'
   $user               = 'oxidized'
   $group              = 'oxidized'
 

--- a/templates/main_options.erb
+++ b/templates/main_options.erb
@@ -1,5 +1,3 @@
 # File is managed by Puppet
 
----
-<% options = scope.lookupvar('oxidized::main::merged_options') -%>
-<%= options.to_yaml.gsub(/^\s{2}/, '') %>
+<%= scope.lookupvar('oxidized::main::merged_options').to_yaml -%>


### PR DESCRIPTION
This is a bit of a miscellaneous set of commits, but all were required to get oxidized up and running on RHEL/CentOS6 using the latest version of oxidized (0.19.0 at time of writing) and while some of the proposed changes may not be backwards compatible they do seem to be necessary to work, at least in my scenario.

I have forked the module with the below changes for internal use, but it would be nice to stick to upstream if possible and these can be merged in.