### PR TITLE
Support rvm on CentOS 7

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@
 class oxidized::install inherits oxidized  {
 
   if $oxidized::gem {
-    if $oxidized::manage_with_rvm and $::facts['os']['family'] == 'RedHat' and $::facts['os']['release']['major'] == '6' {
+    if $oxidized::manage_with_rvm and $::facts['os']['family'] == 'RedHat' and $::facts['os']['release']['major'] in ['6', '7'] {
 
       package { $oxidized::params::dependencies:
         ensure  => $oxidized::ensure,


### PR DESCRIPTION
Oxidized fails to install on CentOS 7 without being in an RVM. 