### PR TITLE
Create a data directory inline with the defaults for Oxidized

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,6 +40,13 @@ class oxidized::config inherits oxidized {
       system     => true,
     }
 
+    file { $data_dir: 
+      ensure => directory,
+      owner  => $oxidized::user,
+      group  => $oxidized::group,
+      mode   => '0640',
+    }
+
     concat { $config_file:
       ensure => present,
       owner  => $oxidized::user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class oxidized::params {
   $custom_config_file   = undef
   $config_dir           = '/etc/oxidized'
   $pid_dir              = '/var/run/oxidized'
+  $data_dir             = '/var/lib/oxidized'
   $manage_user          = true
   $manage_service       = true
   $service_name         = 'oxidized'
@@ -82,7 +83,7 @@ class oxidized::params {
         git      => {
           user   => 'Oxidized',
           email  => 'oxidized@example.com',
-          repo   => '~/.config/oxidized/oxidized.git',
+          repo   => '/var/lib/oxidized/oxidized.git',
         },
     },
     source      => {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "furhouse-oxidized",
-  "version": "0.1.2",
+  "version": "0.1.11",
   "author": "Wim Bonthuis <wim@500k.nl>",
   "summary": "Configures Oxidized, a network device configuration backup tool.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Create a data directory (/var/lib/oxidized in most cases) for data to live in, inline with the documentation from Oxidized. Assign permissions to the directory so that Oxidized can write and read the files within.